### PR TITLE
Refactor/frontend cleanup

### DIFF
--- a/frontend/src/components/AvailableRecordings.tsx
+++ b/frontend/src/components/AvailableRecordings.tsx
@@ -300,6 +300,7 @@ const AvailableRecordings: React.FC<AvailableRecordingsProps> = ({ recordings = 
                           }}
                         >
                           <DetectionsPlayer
+                            key={rec.hlsUrl}
                             hlsUrl={rec.hlsUrl!}
                             startOffsetSec={rec.startOffsetSec!}
                             endOffsetSec={rec.endOffsetSec!}

--- a/frontend/src/components/DetectionsPlayer.tsx
+++ b/frontend/src/components/DetectionsPlayer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import React, { useCallback, useMemo, useRef, useState } from 'react';
 import Image from 'next/image';
 import { Box, IconButton, Slider, Typography } from '@mui/material';
 import VideoJS from '@/components/VideoJS';
@@ -66,13 +66,7 @@ const DetectionsPlayer: React.FC<DetectionsPlayerProps> = ({
     [hlsUrl],
   );
 
-  // Reset when the clip changes
-  useEffect(() => {
-    setPlayerTime(startOffsetSec);
-    setIsPlaying(false);
-  }, [hlsUrl, startOffsetSec]);
-
-  const handlePlayerReady = useCallback(
+const handlePlayerReady = useCallback(
     (player: Player) => {
       playerRef.current = player;
 

--- a/frontend/src/components/DetectionsPlayer.tsx
+++ b/frontend/src/components/DetectionsPlayer.tsx
@@ -18,10 +18,11 @@ interface DetectionsPlayerProps {
 const PLAY_BUTTON_SIZE = 48;
 
 /** Format seconds to zero-padded mm:ss (e.g. "00:00", "04:18") */
-const formattedSeconds = (seconds: number) => {
-  const mm = Math.floor(seconds / 60);
-  const ss = seconds % 60;
-  return `${mm.toString().padStart(2, '0')}:${ss.toFixed(0).padStart(2, '0')}`;
+const formattedSeconds = (seconds: number): string => {
+  const safeSeconds = Math.max(0, Math.floor(seconds));
+  const minutes = Math.floor(safeSeconds / 60);
+  const remainingSeconds = safeSeconds % 60;
+  return `${String(minutes).padStart(2, '0')}:${String(remainingSeconds).padStart(2, '0')}`;
 };
 
 /**
@@ -70,18 +71,14 @@ const handlePlayerReady = useCallback(
     (player: Player) => {
       playerRef.current = player;
 
-      player.on('playing', () => {
-        setIsPlaying(true);
-        const t = player.currentTime() ?? 0;
-        if (t < startOffsetSec || t > endOffsetSec) {
-          player.currentTime(startOffsetSec);
-          setPlayerTime(startOffsetSec);
-        }
+      // Seek to clip start once metadata is loaded and seeking is possible
+      player.one('loadedmetadata', () => {
+        player.currentTime(startOffsetSec);
+        setPlayerTime(startOffsetSec);
       });
 
+      player.on('playing', () => setIsPlaying(true));
       player.on('pause', () => setIsPlaying(false));
-
-      player.currentTime(startOffsetSec);
 
       player.on('timeupdate', () => {
         const t = player.currentTime() ?? 0;


### PR DESCRIPTION
Three changes in DetectionsPlayer.tsx:

  1. Removed useEffect reset: Deleted the useEffect that reset state on clip change, relying on key-based
  remount instead.
  2. Improved formattedSeconds: Added negative number guard, Math.floor for safe integer handling, and
  explicit : string return type.
  3. Fixed player seek timing: Replaced immediate currentTime() call with a loadedmetadata event listener
  to ensure the player is ready before seeking to the clip start.