### PR TITLE
Render live vessel positions on interactive per-site maps

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -13,15 +13,18 @@
         "@mui/material": "^7.3.7",
         "@mui/material-nextjs": "^7.3.7",
         "@tanstack/react-query": "^5.90.21",
+        "leaflet": "^1.9.4",
         "lucide-react": "^0.546.0",
         "mux.js": "^6.3.0",
         "next": "^16.0.2-canary.19",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
+        "react-leaflet": "^5.0.0",
         "video.js": "^8.23.7",
         "videojs-offset": "^2.1.3"
       },
       "devDependencies": {
+        "@types/leaflet": "^1.9.21",
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
@@ -1642,6 +1645,17 @@
         "url": "https://opencollective.com/popperjs"
       }
     },
+    "node_modules/@react-leaflet/core": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@react-leaflet/core/-/core-3.0.0.tgz",
+      "integrity": "sha512-3EWmekh4Nz+pGcr+xjf0KNyYfC3U2JjnkWsh0zcqaexYqmmB5ZhH37kz41JXGmKzpaMZCnPofBBm64i+YrEvGQ==",
+      "license": "Hippocratic-2.1",
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
+    },
     "node_modules/@rtsao/scc": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@rtsao/scc/-/scc-1.1.0.tgz",
@@ -1702,6 +1716,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
       "resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.15.tgz",
@@ -1715,6 +1736,16 @@
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/leaflet": {
+      "version": "1.9.21",
+      "resolved": "https://registry.npmjs.org/@types/leaflet/-/leaflet-1.9.21.tgz",
+      "integrity": "sha512-TbAd9DaPGSnzp6QvtYngntMZgcRk+igFELwR2N99XZn7RXUdKgsXMR+28bUO0rPsWp8MIu/f47luLIQuSLYv/w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "20.19.25",
@@ -4943,6 +4974,12 @@
         "node": ">=0.10"
       }
     },
+    "node_modules/leaflet": {
+      "version": "1.9.4",
+      "resolved": "https://registry.npmjs.org/leaflet/-/leaflet-1.9.4.tgz",
+      "integrity": "sha512-nxS1ynzJOmOlHp+iL3FyWqK89GtNL8U8rvlMOsQdTTssxZwCXh8N2NB3GDQOL+YR3XnWyZAxwQixURb+FA74PA==",
+      "license": "BSD-2-Clause"
+    },
     "node_modules/levn": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.4.1.tgz",
@@ -5644,6 +5681,20 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/react-leaflet": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/react-leaflet/-/react-leaflet-5.0.0.tgz",
+      "integrity": "sha512-CWbTpr5vcHw5bt9i4zSlPEVQdTVcML390TjeDG0cK59z1ylexpqC6M1PJFjV8jD7CF+ACBFsLIDs6DRMoLEofw==",
+      "license": "Hippocratic-2.1",
+      "dependencies": {
+        "@react-leaflet/core": "^3.0.0"
+      },
+      "peerDependencies": {
+        "leaflet": "^1.9.0",
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0"
+      }
     },
     "node_modules/react-transition-group": {
       "version": "4.4.5",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,15 +14,18 @@
     "@mui/material": "^7.3.7",
     "@mui/material-nextjs": "^7.3.7",
     "@tanstack/react-query": "^5.90.21",
+    "leaflet": "^1.9.4",
     "lucide-react": "^0.546.0",
     "mux.js": "^6.3.0",
     "next": "^16.0.2-canary.19",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "react-leaflet": "^5.0.0",
     "video.js": "^8.23.7",
     "videojs-offset": "^2.1.3"
   },
   "devDependencies": {
+    "@types/leaflet": "^1.9.21",
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",

--- a/frontend/src/app/ais-maps/page.tsx
+++ b/frontend/src/app/ais-maps/page.tsx
@@ -1,18 +1,18 @@
 'use client';
 
+import dynamic from 'next/dynamic';
 import { Box, Container, Grid, Paper, Typography } from '@mui/material';
 import Banner from '@/components/Banner';
+import { useAisSite } from '@/hooks/useShipnoiseApi';
+import type { SiteMapSite } from '@/components/SiteMap';
 
-type Site = {
-  slug: string;
-  name: string;
-  lat: number;
-  lon: number;
-};
+const SiteMap = dynamic(() => import('@/components/SiteMap'), {
+  ssr: false,
+});
 
 // Source: https://live.orcasound.net/api/json/feeds (visible: true)
 // Ordered north to south so the grid reads geographically, top to bottom.
-const SITES: Site[] = [
+const SITES: SiteMapSite[] = [
   { slug: 'orcasound-lab', name: 'Orcasound Lab', lat: 48.5583, lon: -123.1736 },
   { slug: 'andrews-bay', name: 'Andrews Bay', lat: 48.5467, lon: -123.1664 },
   { slug: 'north-sjc', name: 'North San Juan Channel', lat: 48.5913, lon: -123.0588 },
@@ -22,34 +22,45 @@ const SITES: Site[] = [
   { slug: 'mast-center', name: 'MaST Center Aquarium', lat: 47.3492, lon: -122.3251 },
 ];
 
-function SiteMapPlaceholder({ site }: { site: Site }) {
+function formatUpdatedLabel(updatedAt: string | null): string {
+  if (!updatedAt) return 'Waiting for first update…';
+  const ageSec = Math.max(0, (Date.now() - new Date(updatedAt).getTime()) / 1000);
+  if (ageSec < 60) return 'Updated just now';
+  const ageMin = Math.round(ageSec / 60);
+  return `Updated ${ageMin} min ago`;
+}
+
+function SiteTile({ site }: { site: SiteMapSite }) {
+  const { data, isLoading } = useAisSite(site.slug);
+  const vessels = data?.vessels ?? [];
+
   return (
-    <Paper
-      variant="outlined"
-      sx={{
-        overflow: 'hidden',
-        borderRadius: 2,
-      }}
-    >
-      <Box
-        sx={{
-          aspectRatio: '4 / 3',
-          bgcolor: '#e8edf1',
-          display: 'flex',
-          alignItems: 'center',
-          justifyContent: 'center',
-        }}
-      >
-        <Typography variant="body2" sx={{ color: '#6b7c85' }}>
-          AIS map coming soon
-        </Typography>
+    <Paper variant="outlined" sx={{ overflow: 'hidden', borderRadius: 2 }}>
+      <Box sx={{ aspectRatio: '4 / 3', bgcolor: '#e8edf1' }}>
+        {isLoading ? (
+          <Box
+            sx={{
+              height: '100%',
+              display: 'flex',
+              alignItems: 'center',
+              justifyContent: 'center',
+            }}
+          >
+            <Typography variant="body2" sx={{ color: '#6b7c85' }}>
+              Loading map…
+            </Typography>
+          </Box>
+        ) : (
+          <SiteMap site={site} vessels={vessels} />
+        )}
       </Box>
       <Box sx={{ p: 1.5 }}>
         <Typography variant="subtitle1" sx={{ fontWeight: 600 }}>
           {site.name}
         </Typography>
         <Typography variant="body2" sx={{ color: 'text.secondary' }}>
-          {site.lat.toFixed(4)}, {site.lon.toFixed(4)}
+          {vessels.length} vessel{vessels.length === 1 ? '' : 's'} nearby &middot;{' '}
+          {formatUpdatedLabel(data?.updated_at ?? null)}
         </Typography>
       </Box>
     </Paper>
@@ -74,7 +85,7 @@ export default function AisMapsPage() {
         <Grid container spacing={2}>
           {SITES.map((site) => (
             <Grid key={site.slug} size={{ xs: 12, sm: 6, md: 4 }}>
-              <SiteMapPlaceholder site={site} />
+              <SiteTile site={site} />
             </Grid>
           ))}
         </Grid>

--- a/frontend/src/components/SiteMap.tsx
+++ b/frontend/src/components/SiteMap.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import 'leaflet/dist/leaflet.css';
+import { CircleMarker, MapContainer, Popup, TileLayer } from 'react-leaflet';
+import type { AisVessel } from '@/lib/api';
+
+export type SiteMapSite = {
+  slug: string;
+  name: string;
+  lat: number;
+  lon: number;
+  radiusNm?: number;
+};
+
+interface SiteMapProps {
+  site: SiteMapSite;
+  vessels: AisVessel[];
+  interactive?: boolean;
+}
+
+const OSM_TILE_URL = 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png';
+const OSM_ATTRIBUTION = '&copy; <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> contributors';
+
+function formatKnots(sog: number | null): string {
+  if (sog === null || Number.isNaN(sog)) return 'unknown speed';
+  return `${sog.toFixed(1)} kn`;
+}
+
+export default function SiteMap({ site, vessels, interactive = true }: SiteMapProps) {
+  const positionedVessels = vessels.filter(
+    (v): v is AisVessel & { lat: number; lon: number } => v.lat !== null && v.lon !== null,
+  );
+
+  return (
+    <MapContainer
+      center={[site.lat, site.lon]}
+      zoom={11}
+      scrollWheelZoom={false}
+      dragging={interactive}
+      doubleClickZoom={interactive}
+      zoomControl={interactive}
+      touchZoom={interactive}
+      style={{ height: '100%', width: '100%' }}
+    >
+      <TileLayer url={OSM_TILE_URL} attribution={OSM_ATTRIBUTION} />
+
+      <CircleMarker
+        center={[site.lat, site.lon]}
+        radius={7}
+        pathOptions={{ color: '#1d4ed8', fillColor: '#1d4ed8', fillOpacity: 0.9 }}
+      >
+        <Popup>{site.name} (hydrophone)</Popup>
+      </CircleMarker>
+
+      {positionedVessels.map((vessel) => (
+        <CircleMarker
+          key={vessel.mmsi ?? `${vessel.lat},${vessel.lon}`}
+          center={[vessel.lat, vessel.lon]}
+          radius={4}
+          pathOptions={{ color: '#dc2626', fillColor: '#dc2626', fillOpacity: 0.85 }}
+        >
+          <Popup>
+            <strong>{vessel.name ?? 'Unknown vessel'}</strong>
+            <br />
+            {formatKnots(vessel.sog)}
+            {vessel.mmsi ? (
+              <>
+                <br />
+                MMSI {vessel.mmsi}
+              </>
+            ) : null}
+          </Popup>
+        </CircleMarker>
+      ))}
+    </MapContainer>
+  );
+}

--- a/frontend/src/hooks/useShipnoiseApi.ts
+++ b/frontend/src/hooks/useShipnoiseApi.ts
@@ -5,10 +5,12 @@ import {
 import {
   fetchVesselSuggestions,
   fetchClipsSearch,
+  fetchAisSite,
   normalizeNameForSearch,
   type VesselOption,
   type ClipsSearchParams,
   type ClipsSearchResponse,
+  type AisSiteResponse,
 } from '@/lib/api';
 
 /**
@@ -24,6 +26,22 @@ export function useVesselSearch(query: string) {
     enabled: normalized.length > 0,
     placeholderData: keepPreviousData,
     staleTime: 60_000,
+  });
+}
+
+/**
+ * Polls cached AIS vessel data for one hydrophone site. The backend enforces
+ * the AISHub rate limit itself, so it's safe to poll this on a short interval
+ * from as many mounted tiles as are on screen.
+ */
+export function useAisSite(slug: string) {
+  return useQuery<AisSiteResponse>({
+    queryKey: ['ais', 'site', slug],
+    queryFn: ({ signal }) => fetchAisSite(slug, signal),
+    placeholderData: keepPreviousData,
+    staleTime: 20_000,
+    refetchInterval: 30_000,
+    retry: 1,
   });
 }
 

--- a/frontend/src/lib/api.ts
+++ b/frontend/src/lib/api.ts
@@ -101,6 +101,35 @@ export interface ClipsSearchParams {
   limitPerSite?: number;
 }
 
+export type AisVessel = {
+  mmsi: number | null;
+  name: string | null;
+  lat: number | null;
+  lon: number | null;
+  sog: number | null;
+  cog: number | null;
+  type: number | null;
+  navstat: number | null;
+  time: string | null;
+};
+
+export type AisSiteResponse = {
+  site: string;
+  vessels: AisVessel[];
+  updated_at: string | null;
+  error: string | null;
+};
+
+export async function fetchAisSite(slug: string, signal?: AbortSignal): Promise<AisSiteResponse> {
+  const url = buildBackendUrl(`/ais/sites/${slug}`, new URLSearchParams());
+  if (!url) throw new Error('NEXT_PUBLIC_CLIPS_API_BASE_URL is not configured');
+
+  const response = await fetch(url, { signal });
+  if (!response.ok) throw new Error(`AIS site request failed with ${response.status}`);
+
+  return response.json();
+}
+
 export async function fetchClipsSearch(
   params: ClipsSearchParams,
   signal?: AbortSignal,


### PR DESCRIPTION
## Summary
- Replaces the `/ais-maps` placeholder tiles with real interactive Leaflet maps (OSM raster tiles): each shows the hydrophone location (blue marker) plus live nearby vessel positions (red markers, click for name/speed/MMSI), fed by `GET /ais/sites/{slug}` from #84.
- Each tile polls its site every 30s via `react-query`. The backend owns the actual AISHub rate limit and caching, so polling from up to 7 mounted tiles (or many concurrent users) never risks exceeding it — the frontend just reads whatever's cached.
- Tile footer now shows live vessel count and a human "Updated N min ago" freshness label instead of static placeholder text.
- `SiteMap` is loaded via `next/dynamic({ ssr: false })` since Leaflet touches `window` at import time and isn't SSR-safe.

## Stacking / dependencies
This branches off #83 (page skeleton) and needs #84 (AIS backend service) merged/deployed for `/ais/sites/{slug}` to return real data in production — locally I ran the backend from the `ais-map-data` branch to test against. Once #83 merges, GitHub should retarget this PR's base to `main` automatically.

## Test plan
- [x] `tsc --noEmit`, `eslint`, and `next build` all pass
- [x] Verified locally against a live backend instance (real AISHub data): all 7 tiles render OSM maps with geographically correct vessel clusters (San Juan Island group, Whidbey Island, Everett/Edmonds, Tacoma-area)
- [x] Confirmed vessel counts and "updated N min ago" labels update correctly as the backend's cache refreshes
- [x] Confirmed marker popups show vessel name/speed/MMSI